### PR TITLE
state manager bug fix

### DIFF
--- a/src/parameters/StateManager.cpp
+++ b/src/parameters/StateManager.cpp
@@ -141,16 +141,15 @@ void StateManager::load_preset(juce::String preset_name) {
 }
 
 void StateManager::load_from(juce::XmlElement *xml) {
-  if (xml != nullptr) {
-    if (xml->hasTagName(STATE_ID)) {
-      auto new_tree = juce::ValueTree::fromXml(*xml);
-      param_tree_ptr->state.copyPropertiesAndChildrenFrom(new_tree.getChildWithName(PARAMETERS_ID),
-                                                          &undo_manager);
-      property_tree.copyPropertiesFrom(new_tree.getChildWithName(PROPERTIES_ID), &undo_manager);
-      preset_tree.copyPropertiesFrom(new_tree.getChildWithName(PRESET_ID), &undo_manager);
-      preset_modified.store(false);
+    if (xml != nullptr) {
+        if (xml->hasTagName(STATE_ID)) {
+            auto new_tree = juce::ValueTree::fromXml(*xml);
+            param_tree_ptr->replaceState(new_tree.getChildWithName(PARAMETERS_ID));
+            property_tree.copyPropertiesFrom(new_tree.getChildWithName(PROPERTIES_ID), &undo_manager);
+            preset_tree.copyPropertiesFrom(new_tree.getChildWithName(PRESET_ID), &undo_manager);
+            preset_modified.store(false);
+        }
     }
-  }
 }
 
 void StateManager::set_preset_name(juce::String preset_name) {


### PR DESCRIPTION
you may have a specific reason for doing load_from(juce::XmlElement *xml) how you were doing it before, but it was causing parameters after my 62nd parameter to stop loading correctly when I copy and pasted the plugin onto a track